### PR TITLE
フェーズ1: MCP Bridgeの基本実装 (Issue #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# SPACO (SuperCollider And Claude Orchestration)
+
+SPACO（SuperCollider And Claude Orchestration）は、Claude DesktopとSuperColliderを連携させ、自然言語による音響合成や映像制作の指示をSuperColliderで実現するシステムです。
+
+## プロジェクト構造
+
+```
+/Users/mymac/spaco/
+├── src/                   # ソースコード
+│   ├── bridge/            # MCP Bridge
+│   │   ├── handlers/      # リクエストハンドラー
+│   │   ├── bridge.py      # メインブリッジクラス
+│   │   ├── mcp_server.py  # MCPサーバー
+│   │   └── response_generator.py # レスポンス生成
+│   └── __init__.py
+└── tests/                 # テスト
+    └── test_mcp_bridge.py # MCP Bridgeのテスト
+```
+
+## 使用方法
+
+SPACOは現在開発中であり、基本的な機能のみが実装されています。以下に簡単な使用例を示します：
+
+```python
+from spaco.src.bridge import SPACOBridge
+
+# SPACOブリッジを作成して起動
+bridge = SPACOBridge(host="localhost", port=8080)
+bridge.start()
+```
+
+## MCPブリッジ
+
+MCPブリッジは、Claude DesktopからModel Context Protocol (MCP)を通じて送信された指示を受け取り、SuperColliderで実行できるコードに変換します。現在の実装では以下の機能を提供しています：
+
+1. MCPリクエストを受け付けるHTTPサーバー
+2. 音響合成指示の簡易的な処理
+3. SuperColliderコードの生成と実行
+4. エラー処理とフィードバック
+
+## 次のステップ
+
+1. SuperCollider Interfaceの実装
+2. 自然言語処理機能の強化
+3. 音響合成パターンライブラリの充実
+4. ユーザーインターフェースの改善
+
+## ライセンス
+
+このプロジェクトはMITライセンスの下で公開されています。

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,7 @@
+"""SPACO (SuperCollider And Claude Orchestration).
+
+This package provides functionality to translate natural language instructions
+into SuperCollider code for audio synthesis and music production.
+"""
+
+__version__ = "0.1.0"

--- a/src/bridge/__init__.py
+++ b/src/bridge/__init__.py
@@ -1,0 +1,8 @@
+"""MCP Bridge for SPACO.
+
+This module provides the bridge between Claude Desktop and SuperCollider
+using the Model Context Protocol (MCP).
+"""
+
+from .mcp_server import MCPServer
+from .bridge import SPACOBridge

--- a/src/bridge/bridge.py
+++ b/src/bridge/bridge.py
@@ -1,0 +1,71 @@
+"""SPACO Bridge for connecting Claude Desktop with SuperCollider.
+
+This module provides the main bridge component that connects
+Claude Desktop with SuperCollider using the MCP protocol.
+"""
+
+import logging
+import asyncio
+from .mcp_server import MCPServer
+from .handlers.sound_handler import SoundHandler
+
+class SPACOBridge:
+    """
+    Main bridge connecting Claude Desktop with SuperCollider.
+    
+    This class sets up and manages the connection between Claude Desktop
+    and SuperCollider, handling MCP requests and responses.
+    """
+    
+    def __init__(self, host="localhost", port=8080, sc_interface=None):
+        """
+        Initialize a SPACOBridge.
+        
+        Args:
+            host (str): Host for the MCP server
+            port (int): Port for the MCP server
+            sc_interface: Interface to SuperCollider
+        """
+        self.logger = self._setup_logger()
+        self.mcp_server = MCPServer(host, port)
+        self.sc_interface = sc_interface
+        
+        # Set up handlers
+        self.sound_handler = SoundHandler(sc_interface)
+        
+        # Register handlers with the MCP server
+        self._register_handlers()
+    
+    def _setup_logger(self):
+        """Set up logger for the bridge."""
+        logger = logging.getLogger('spaco_bridge')
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        return logger
+    
+    def _register_handlers(self):
+        """Register handlers with the MCP server."""
+        # Sound-related handlers
+        self.mcp_server.register_handler('generate_sound', self.sound_handler.handle_generate_sound)
+        self.mcp_server.register_handler('stop_sound', self.sound_handler.handle_stop_sound)
+    
+    def start(self):
+        """Start the bridge."""
+        self.logger.info("Starting SPACO Bridge")
+        try:
+            self.mcp_server.start()
+        except KeyboardInterrupt:
+            self.logger.info("Stopping SPACO Bridge")
+    
+    async def start_async(self):
+        """Start the bridge asynchronously."""
+        self.logger.info("Starting SPACO Bridge asynchronously")
+        return await self.mcp_server.start_async()
+    
+    def stop(self):
+        """Stop the bridge."""
+        self.logger.info("Stopping SPACO Bridge")
+        # Additional cleanup if needed

--- a/src/bridge/handlers/__init__.py
+++ b/src/bridge/handlers/__init__.py
@@ -1,0 +1,4 @@
+"""Handlers for SPACO MCP Bridge.
+
+This package contains handlers for various MCP request types.
+"""

--- a/src/bridge/handlers/sound_handler.py
+++ b/src/bridge/handlers/sound_handler.py
@@ -1,0 +1,126 @@
+"""Sound Handler for SPACO MCP Bridge.
+
+This module provides a handler for sound-related MCP requests.
+"""
+
+import json
+import logging
+
+class SoundHandler:
+    """
+    Handler for sound-related MCP requests.
+    
+    This class provides methods to handle sound generation, modification,
+    and other sound-related requests from Claude Desktop.
+    """
+    
+    def __init__(self, sc_interface=None):
+        """
+        Initialize a SoundHandler.
+        
+        Args:
+            sc_interface: Interface to SuperCollider
+        """
+        self.sc_interface = sc_interface
+        self.logger = logging.getLogger('sound_handler')
+    
+    async def handle_generate_sound(self, request):
+        """
+        Handle a request to generate a sound.
+        
+        Args:
+            request (dict): The request
+        
+        Returns:
+            dict: The response
+        """
+        self.logger.info(f"Handling generate_sound request: {request}")
+        
+        # Extract parameters from request
+        instruction = request.get('instruction', '')
+        parameters = request.get('parameters', {})
+        
+        # Validate request
+        if not instruction:
+            return {
+                "success": False,
+                "error": "Missing 'instruction' field in request"
+            }
+        
+        # Generate SuperCollider code (this is a placeholder until later phases)
+        code = self._generate_placeholder_code(instruction, parameters)
+        
+        # Execute code if SuperCollider interface is available
+        execution_result = None
+        if self.sc_interface:
+            try:
+                execution_result = await self.sc_interface.execute(code)
+            except Exception as e:
+                self.logger.error(f"Error executing code: {str(e)}", exc_info=True)
+                return {
+                    "success": False,
+                    "error": f"Error executing code: {str(e)}",
+                    "code": code
+                }
+        
+        # Return the result
+        return {
+            "success": True,
+            "code": code,
+            "execution_result": execution_result
+        }
+    
+    async def handle_stop_sound(self, request):
+        """
+        Handle a request to stop sound generation.
+        
+        Args:
+            request (dict): The request
+        
+        Returns:
+            dict: The response
+        """
+        self.logger.info("Handling stop_sound request")
+        
+        # Stop sound if SuperCollider interface is available
+        if self.sc_interface:
+            try:
+                await self.sc_interface.stop_all()
+                return {"success": True, "message": "All sounds stopped"}
+            except Exception as e:
+                self.logger.error(f"Error stopping sounds: {str(e)}", exc_info=True)
+                return {"success": False, "error": f"Error stopping sounds: {str(e)}"}
+        else:
+            return {"success": False, "error": "SuperCollider interface not available"}
+    
+    def _generate_placeholder_code(self, instruction, parameters):
+        """
+        Generate placeholder SuperCollider code.
+        
+        Args:
+            instruction (str): The instruction
+            parameters (dict): The parameters
+        
+        Returns:
+            str: The SuperCollider code
+        """
+        # This is a simple placeholder implementation
+        # In later phases, this will be replaced with the actual NLP -> code generation
+        
+        freq = parameters.get('frequency', 440)
+        amp = parameters.get('amplitude', 0.5)
+        duration = parameters.get('duration', 1)
+        
+        code = f"""
+        // Generated from instruction: {instruction}
+        s.waitForBoot({{
+            {{
+                var sig = SinOsc.ar({freq}, 0, {amp});
+                var env = EnvGen.kr(Env.linen(0.01, {duration}, 0.01), doneAction: 2);
+                sig = sig * env;
+                sig ! 2 // Stereo output
+            }}.play;
+        }});
+        """
+        
+        return code

--- a/src/bridge/mcp_server.py
+++ b/src/bridge/mcp_server.py
@@ -1,0 +1,142 @@
+"""MCP Server for SPACO.
+
+This module provides a server for handling MCP requests from Claude Desktop.
+"""
+
+import json
+import logging
+import asyncio
+from aiohttp import web
+
+class MCPServer:
+    """
+    Server for handling MCP requests from Claude Desktop.
+    
+    This class provides a server that accepts MCP requests from Claude Desktop,
+    processes them, and returns responses.
+    """
+    
+    def __init__(self, host="localhost", port=8080):
+        """
+        Initialize an MCPServer.
+        
+        Args:
+            host (str): Host to listen on
+            port (int): Port to listen on
+        """
+        self.host = host
+        self.port = port
+        self.app = web.Application()
+        self.handlers = {}
+        self.logger = self._setup_logger()
+        
+        # Set up routes
+        self.app.router.add_post('/mcp', self.handle_mcp_request)
+        self.app.router.add_get('/status', self.handle_status)
+    
+    def _setup_logger(self):
+        """Set up logger for the server."""
+        logger = logging.getLogger('mcp_server')
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        return logger
+    
+    def register_handler(self, action_type, handler):
+        """
+        Register a handler for an action type.
+        
+        Args:
+            action_type (str): The action type to handle
+            handler (callable): The handler function
+        """
+        self.handlers[action_type] = handler
+        self.logger.info(f"Registered handler for action type: {action_type}")
+    
+    async def handle_mcp_request(self, request):
+        """
+        Handle an MCP request.
+        
+        Args:
+            request: The web request
+        
+        Returns:
+            web.Response: The response
+        """
+        try:
+            # Parse request body as JSON
+            body = await request.json()
+            self.logger.info(f"Received MCP request: {body}")
+            
+            # Check if the request is valid
+            if 'action' not in body:
+                return self._error_response("Missing 'action' field in request")
+            
+            action = body['action']
+            
+            # Check if there's a handler for this action
+            if action not in self.handlers:
+                return self._error_response(f"No handler for action: {action}")
+            
+            # Call the handler
+            handler = self.handlers[action]
+            result = await handler(body)
+            
+            # Return the result
+            return web.json_response({
+                "status": "success",
+                "result": result
+            })
+            
+        except json.JSONDecodeError:
+            return self._error_response("Invalid JSON in request body")
+        except Exception as e:
+            self.logger.error(f"Error handling request: {str(e)}", exc_info=True)
+            return self._error_response(f"Internal server error: {str(e)}")
+    
+    async def handle_status(self, request):
+        """
+        Handle a status request.
+        
+        Args:
+            request: The web request
+        
+        Returns:
+            web.Response: The response
+        """
+        return web.json_response({
+            "status": "running",
+            "handlers": list(self.handlers.keys())
+        })
+    
+    def _error_response(self, message):
+        """
+        Create an error response.
+        
+        Args:
+            message (str): The error message
+        
+        Returns:
+            web.Response: The error response
+        """
+        self.logger.error(message)
+        return web.json_response({
+            "status": "error",
+            "message": message
+        }, status=400)
+    
+    def start(self):
+        """Start the server."""
+        self.logger.info(f"Starting MCP server on {self.host}:{self.port}")
+        web.run_app(self.app, host=self.host, port=self.port)
+    
+    async def start_async(self):
+        """Start the server asynchronously."""
+        self.logger.info(f"Starting MCP server on {self.host}:{self.port}")
+        runner = web.AppRunner(self.app)
+        await runner.setup()
+        site = web.TCPSite(runner, self.host, self.port)
+        await site.start()
+        return runner

--- a/src/bridge/response_generator.py
+++ b/src/bridge/response_generator.py
@@ -1,0 +1,128 @@
+"""Response Generator for SPACO MCP Bridge.
+
+This module provides functionality for generating responses to
+MCP requests from Claude Desktop.
+"""
+
+import json
+import logging
+
+class ResponseGenerator:
+    """
+    Generates responses to MCP requests from Claude Desktop.
+    
+    This class provides methods for formatting and sending responses
+    back to Claude Desktop using the MCP protocol.
+    """
+    
+    def __init__(self):
+        """Initialize a ResponseGenerator."""
+        self.logger = logging.getLogger('response_generator')
+    
+    def generate_success_response(self, result, context=None):
+        """
+        Generate a success response.
+        
+        Args:
+            result: The result to include in the response
+            context (dict, optional): Additional context information
+        
+        Returns:
+            dict: The MCP response
+        """
+        response = {
+            "status": "success",
+            "result": result
+        }
+        
+        if context:
+            response["context"] = context
+        
+        self.logger.debug(f"Generated success response: {response}")
+        return response
+    
+    def generate_error_response(self, message, error_code=None, context=None):
+        """
+        Generate an error response.
+        
+        Args:
+            message (str): The error message
+            error_code (str, optional): An error code
+            context (dict, optional): Additional context information
+        
+        Returns:
+            dict: The MCP response
+        """
+        response = {
+            "status": "error",
+            "message": message
+        }
+        
+        if error_code:
+            response["error_code"] = error_code
+        
+        if context:
+            response["context"] = context
+        
+        self.logger.warning(f"Generated error response: {response}")
+        return response
+    
+    def generate_progress_response(self, progress, message=None, context=None):
+        """
+        Generate a progress response.
+        
+        Args:
+            progress (float): The progress percentage (0-100)
+            message (str, optional): A progress message
+            context (dict, optional): Additional context information
+        
+        Returns:
+            dict: The MCP response
+        """
+        response = {
+            "status": "progress",
+            "progress": progress
+        }
+        
+        if message:
+            response["message"] = message
+        
+        if context:
+            response["context"] = context
+        
+        self.logger.debug(f"Generated progress response: {response}")
+        return response
+    
+    def format_code_for_claude(self, code, language="supercollider"):
+        """
+        Format code for display in Claude Desktop.
+        
+        Args:
+            code (str): The code to format
+            language (str, optional): The programming language
+        
+        Returns:
+            str: The formatted code
+        """
+        return f"```{language}\n{code}\n```"
+    
+    def format_audio_response(self, audio_url, description=None):
+        """
+        Format an audio response for Claude Desktop.
+        
+        Args:
+            audio_url (str): URL to the generated audio
+            description (str, optional): Description of the audio
+        
+        Returns:
+            dict: The formatted audio response
+        """
+        response = {
+            "type": "audio",
+            "url": audio_url
+        }
+        
+        if description:
+            response["description"] = description
+        
+        return response

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+"""Tests for SPACO.
+
+This package contains tests for various SPACO components.
+"""

--- a/tests/test_mcp_bridge.py
+++ b/tests/test_mcp_bridge.py
@@ -1,0 +1,227 @@
+"""Tests for MCP Bridge.
+
+This module contains tests for the MCP Bridge component.
+"""
+
+import unittest
+import asyncio
+import json
+from unittest.mock import Mock, patch
+from aiohttp import web
+from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
+
+from src.bridge.mcp_server import MCPServer
+from src.bridge.bridge import SPACOBridge
+from src.bridge.handlers.sound_handler import SoundHandler
+from src.bridge.response_generator import ResponseGenerator
+
+class TestMCPServer(unittest.TestCase):
+    """Tests for MCPServer class."""
+    
+    def setUp(self):
+        """Set up the test case."""
+        self.server = MCPServer(host="localhost", port=8080)
+    
+    def test_init(self):
+        """Test initialization."""
+        self.assertEqual(self.server.host, "localhost")
+        self.assertEqual(self.server.port, 8080)
+        self.assertIsInstance(self.server.app, web.Application)
+        self.assertEqual(self.server.handlers, {})
+    
+    def test_register_handler(self):
+        """Test registering a handler."""
+        handler = Mock()
+        self.server.register_handler("test_action", handler)
+        self.assertEqual(self.server.handlers["test_action"], handler)
+    
+    @patch('aiohttp.web.json_response')
+    def test_error_response(self, mock_json_response):
+        """Test error response generation."""
+        self.server._error_response("Test error")
+        mock_json_response.assert_called_once_with({
+            "status": "error",
+            "message": "Test error"
+        }, status=400)
+
+
+class TestSoundHandler(unittest.TestCase):
+    """Tests for SoundHandler class."""
+    
+    def setUp(self):
+        """Set up the test case."""
+        self.sc_interface = Mock()
+        self.handler = SoundHandler(self.sc_interface)
+    
+    @patch('logging.Logger.info')
+    async def test_handle_generate_sound(self, mock_logger):
+        """Test handling a generate_sound request."""
+        request = {
+            "instruction": "Generate a 440Hz sine wave",
+            "parameters": {
+                "frequency": 440,
+                "amplitude": 0.5,
+                "duration": 1
+            }
+        }
+        
+        self.sc_interface.execute = Mock(return_value={"stdout": "", "stderr": ""})
+        
+        result = await self.handler.handle_generate_sound(request)
+        
+        self.assertTrue(result["success"])
+        self.assertIn("code", result)
+        self.sc_interface.execute.assert_called_once()
+    
+    async def test_handle_generate_sound_missing_instruction(self):
+        """Test handling a generate_sound request with a missing instruction."""
+        request = {
+            "parameters": {
+                "frequency": 440
+            }
+        }
+        
+        result = await self.handler.handle_generate_sound(request)
+        
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error"], "Missing 'instruction' field in request")
+    
+    async def test_handle_stop_sound(self):
+        """Test handling a stop_sound request."""
+        request = {}
+        
+        self.sc_interface.stop_all = Mock()
+        
+        result = await self.handler.handle_stop_sound(request)
+        
+        self.assertTrue(result["success"])
+        self.sc_interface.stop_all.assert_called_once()
+    
+    def test_generate_placeholder_code(self):
+        """Test generating placeholder code."""
+        instruction = "Generate a 440Hz sine wave"
+        parameters = {
+            "frequency": 440,
+            "amplitude": 0.5,
+            "duration": 1
+        }
+        
+        code = self.handler._generate_placeholder_code(instruction, parameters)
+        
+        self.assertIn("SinOsc.ar(440", code)
+        self.assertIn("0.5", code)
+        self.assertIn("Generated from instruction", code)
+
+
+class TestResponseGenerator(unittest.TestCase):
+    """Tests for ResponseGenerator class."""
+    
+    def setUp(self):
+        """Set up the test case."""
+        self.generator = ResponseGenerator()
+    
+    def test_generate_success_response(self):
+        """Test generating a success response."""
+        result = {"data": "test"}
+        response = self.generator.generate_success_response(result)
+        
+        self.assertEqual(response["status"], "success")
+        self.assertEqual(response["result"], result)
+    
+    def test_generate_error_response(self):
+        """Test generating an error response."""
+        message = "Test error"
+        response = self.generator.generate_error_response(message, error_code="E001")
+        
+        self.assertEqual(response["status"], "error")
+        self.assertEqual(response["message"], message)
+        self.assertEqual(response["error_code"], "E001")
+    
+    def test_generate_progress_response(self):
+        """Test generating a progress response."""
+        progress = 50.5
+        message = "Halfway there"
+        response = self.generator.generate_progress_response(progress, message)
+        
+        self.assertEqual(response["status"], "progress")
+        self.assertEqual(response["progress"], progress)
+        self.assertEqual(response["message"], message)
+    
+    def test_format_code_for_claude(self):
+        """Test formatting code for Claude Desktop."""
+        code = "var sig = SinOsc.ar(440);"
+        formatted = self.generator.format_code_for_claude(code)
+        
+        self.assertEqual(formatted, "```supercollider\nvar sig = SinOsc.ar(440);\n```")
+
+
+class TestMCPServerIntegration(AioHTTPTestCase):
+    """Integration tests for MCPServer class."""
+    
+    async def get_application(self):
+        """Get the application for testing."""
+        server = MCPServer(host="localhost", port=8080)
+        
+        async def mock_handler(request):
+            return {"result": "ok"}
+        
+        server.register_handler("test_action", mock_handler)
+        return server.app
+    
+    @unittest_run_loop
+    async def test_handle_mcp_request_valid(self):
+        """Test handling a valid MCP request."""
+        request_data = {
+            "action": "test_action",
+            "data": "test"
+        }
+        
+        resp = await self.client.post('/mcp', json=request_data)
+        self.assertEqual(resp.status, 200)
+        
+        data = await resp.json()
+        self.assertEqual(data["status"], "success")
+        self.assertEqual(data["result"]["result"], "ok")
+    
+    @unittest_run_loop
+    async def test_handle_mcp_request_invalid_action(self):
+        """Test handling an MCP request with an invalid action."""
+        request_data = {
+            "action": "invalid_action",
+            "data": "test"
+        }
+        
+        resp = await self.client.post('/mcp', json=request_data)
+        self.assertEqual(resp.status, 400)
+        
+        data = await resp.json()
+        self.assertEqual(data["status"], "error")
+        self.assertIn("No handler for action", data["message"])
+    
+    @unittest_run_loop
+    async def test_handle_mcp_request_missing_action(self):
+        """Test handling an MCP request with a missing action."""
+        request_data = {
+            "data": "test"
+        }
+        
+        resp = await self.client.post('/mcp', json=request_data)
+        self.assertEqual(resp.status, 400)
+        
+        data = await resp.json()
+        self.assertEqual(data["status"], "error")
+        self.assertEqual(data["message"], "Missing 'action' field in request")
+    
+    @unittest_run_loop
+    async def test_handle_status(self):
+        """Test handling a status request."""
+        resp = await self.client.get('/status')
+        self.assertEqual(resp.status, 200)
+        
+        data = await resp.json()
+        self.assertEqual(data["status"], "running")
+        self.assertIn("test_action", data["handlers"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
このPRはIssue #2「フェーズ1: MCP Bridgeの基本実装」を実装するものです。

## 実装内容
- Claude Desktopからリクエストを受け取る基本的なMCPサーバーを実装
- MCPメッセージを解析するリクエストハンドラーを作成
- Claudeに結果を送り返すレスポンスジェネレーターを実装
- 基本的なロギングとエラー処理を追加
- MCP Bridgeのユニットテストを作成

## 主要コンポーネント
- `mcp_server.py`: Claude Desktopからのリクエストを受け付けるHTTPサーバー
- `sound_handler.py`: 音響合成リクエストを処理するハンドラー
- `response_generator.py`: Claudeに結果を返すためのレスポンス生成
- `bridge.py`: 各コンポーネントを統合するメインブリッジクラス

## 動作確認方法
1. `python -m src.bridge.bridge`でサーバーを起動
2. ポート8080にMCPリクエストを送信

Closes #2