### PR TITLE
フェーズ1: MCP Bridgeの基本実装 (Issue #3)

### DIFF
--- a/src/bridge/response_generator.py
+++ b/src/bridge/response_generator.py
@@ -104,7 +104,9 @@ class ResponseGenerator:
         Returns:
             str: The formatted code
         """
-        return f"```{language}\n{code}\n```"
+        return f"```{language}\
+{code}\
+```"
     
     def format_audio_response(self, audio_url, description=None):
         """

--- a/tests/test_mcp_bridge.py
+++ b/tests/test_mcp_bridge.py
@@ -152,7 +152,9 @@ class TestResponseGenerator(unittest.TestCase):
         code = "var sig = SinOsc.ar(440);"
         formatted = self.generator.format_code_for_claude(code)
         
-        self.assertEqual(formatted, "```supercollider\nvar sig = SinOsc.ar(440);\n```")
+        self.assertEqual(formatted, "```supercollider\
+var sig = SinOsc.ar(440);\
+```")
 
 
 class TestMCPServerIntegration(AioHTTPTestCase):


### PR DESCRIPTION
このPRはIssue #3「フェーズ1: MCP Bridgeの基本実装」を実装するものです。

## 実装内容
- Claude Desktopからリクエストを受け取る基本的なMCPサーバーを実装
- MCPメッセージを解析するリクエストハンドラーを作成
- Claudeに結果を送り返すレスポンスジェネレーターを実装
- 基本的なロギングとエラー処理を追加
- MCP Bridgeのユニットテストを作成

## 主要コンポーネント
- `mcp_server.py`: Claude Desktopからのリクエストを受け付けるHTTPサーバー
- `sound_handler.py`: 音響合成リクエストを処理するハンドラー
- `response_generator.py`: Claudeに結果を返すためのレスポンス生成
- `bridge.py`: 各コンポーネントを統合するメインブリッジクラス

## 動作確認方法
1. `python -m src.bridge.bridge`でサーバーを起動
2. ポート8080にMCPリクエストを送信

Closes #3